### PR TITLE
Simple config + resilient API calls

### DIFF
--- a/.env.backup
+++ b/.env.backup
@@ -1,0 +1,3 @@
+API_ENDPOINT_PRIVATE_GRAPHQL='http://localhost:3000/api/private/non-interactive/graphql'
+AUTH_ADMIN_EMAIL=valentin@alkem.io
+AUTH_ADMIN_PASSWORD=@lk3m10!

--- a/cli.yml
+++ b/cli.yml
@@ -1,0 +1,16 @@
+default:
+  filters:
+    users:
+      include:
+      exclude:
+    organizations:
+      include:
+      exclude:
+    hubs:
+      include:
+        - ef42661b-d7e0-40e8-a763-5b69b2b3a365
+      exclude:
+  retries:
+    retry_count: 3
+    interval: 5
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.0.1",
         "graphql": "^16.6.0",
         "graphql-upload": "^16.0.1",
+        "node-yaml-config": "^1.0.0",
         "nodemon": "^2.0.6",
         "rimraf": "^3.0.2",
         "typescript": "^4.7.4",
@@ -2379,8 +2380,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -4369,6 +4369,14 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -4557,7 +4565,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5107,6 +5114,27 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+    },
+    "node_modules/node-yaml-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-yaml-config/-/node-yaml-config-1.0.0.tgz",
+      "integrity": "sha512-mj7Ww/Oo4JrEsofvOZz7gUrplpAo1qlAfaQd1AfUhWTRK7GkgOtJEUW2a4dlRUIgvkLN3SNmEnp39fU7ri/jMw==",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "node.extend": "^2.0.2"
+      }
+    },
+    "node_modules/node.extend": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
+      "dependencies": {
+        "has": "^1.0.3",
+        "is": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "2.0.19",
@@ -8668,8 +8696,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -10148,6 +10175,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
+    },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -10289,7 +10321,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -10710,6 +10741,24 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+    },
+    "node-yaml-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-yaml-config/-/node-yaml-config-1.0.0.tgz",
+      "integrity": "sha512-mj7Ww/Oo4JrEsofvOZz7gUrplpAo1qlAfaQd1AfUhWTRK7GkgOtJEUW2a4dlRUIgvkLN3SNmEnp39fU7ri/jMw==",
+      "requires": {
+        "js-yaml": "^4.1.0",
+        "node.extend": "^2.0.2"
+      }
+    },
+    "node.extend": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
+      "requires": {
+        "has": "^1.0.3",
+        "is": "^3.2.1"
+      }
     },
     "nodemon": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "delete-organization": "ts-node-dev src/delete-organization.ts",
     "remove-user-from-organizations": "ts-node-dev src/remove-user-from-organizations.ts",
     "authorization-reset-platform": "ts-node-dev src/authorization-reset-platform.ts",
+    "authorization-reset-with-config": "ts-node-dev src/authorization-reset-all.ts true",
     "authorization-reset-all": "ts-node-dev src/authorization-reset-all.ts",
     "authorization-reset-all-users": "ts-node-dev src/authorization-reset-all-users.ts",
     "authorization-reset-all-hubs": "ts-node-dev src/authorization-reset-all-hubs.ts",
@@ -43,13 +44,13 @@
   },
   "homepage": "https://github.com/alkem-io/pcli#readme",
   "devDependencies": {
-    "@types/node": "^14.6.0",
-    "@typescript-eslint/eslint-plugin": "^4.9.0",
-    "@typescript-eslint/parser": "^4.9.0",
     "@graphql-codegen/add": "^3.2.1",
     "@graphql-codegen/cli": "2.11.8",
     "@graphql-codegen/typescript": "2.7.3",
     "@graphql-codegen/typescript-resolvers": "2.7.3",
+    "@types/node": "^14.6.0",
+    "@typescript-eslint/eslint-plugin": "^4.9.0",
+    "@typescript-eslint/parser": "^4.9.0",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
@@ -61,13 +62,14 @@
     "@graphql-codegen/typescript-graphql-request": "^4.5.3",
     "@graphql-codegen/typescript-operations": "^2.5.3",
     "@types/graphql-upload": "^8.0.11",
+    "dotenv": "^16.0.1",
     "graphql": "^16.6.0",
     "graphql-upload": "^16.0.1",
-    "typescript": "^4.7.4",
-    "winston": "^3.8.1",
-    "dotenv": "^16.0.1",
+    "node-yaml-config": "^1.0.0",
     "nodemon": "^2.0.6",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "typescript": "^4.7.4",
+    "winston": "^3.8.1"
   },
   "files": [
     "dist/**/*"

--- a/src/authorization-reset-all.ts
+++ b/src/authorization-reset-all.ts
@@ -3,10 +3,11 @@ import { resetAllHubs } from './authorization-reset-all-hubs';
 import { resetAllOrganizations } from './authorization-reset-all-organizations';
 import { resetPlatform } from './authorization-reset-platform';
 
-const main = async () => {
-  await resetAllUsers();
-  await resetAllHubs();
-  await resetAllOrganizations();
+const main = async (useConfig = false) => {
+  if (process.argv[2]) useConfig = process.argv[2] === 'true';
+  await resetAllUsers(useConfig);
+  await resetAllHubs(useConfig);
+  await resetAllOrganizations(useConfig);
   await resetPlatform();
 };
 

--- a/src/util/filter-entities.ts
+++ b/src/util/filter-entities.ts
@@ -1,0 +1,41 @@
+import { load } from 'node-yaml-config';
+
+export enum EntityType {
+  HUB,
+  ORGANIZATION,
+  USER,
+}
+
+export function shouldProcessEntity(
+  entityId: string,
+  entityType: EntityType
+): boolean {
+  const config = load('cli.yml');
+  let includeIDs: string[] = [];
+  let excludeIDs: string[] = [];
+
+  switch (entityType) {
+    case EntityType.HUB:
+      excludeIDs = config.filters.hubs.exclude;
+      includeIDs = config.filters.hubs.include;
+      break;
+    case EntityType.ORGANIZATION:
+      excludeIDs = config.filters.organizations.exclude;
+      includeIDs = config.filters.organizations.include;
+      break;
+    case EntityType.USER:
+      excludeIDs = config.filters.users.exclude;
+      includeIDs = config.filters.users.include;
+      break;
+  }
+
+  //if we have a list of entities to be excluded it invalidates the include list
+  if (excludeIDs && excludeIDs.length > 0) {
+    if (excludeIDs.includes(entityId)) return false;
+    else return true;
+  }
+  if (includeIDs && includeIDs.length > 0 && !includeIDs.includes(entityId))
+    return false;
+
+  return true;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,1 +1,4 @@
 export * from './create-logger';
+export * from './sleep';
+export * from './retry-function';
+export * from './filter-entities';

--- a/src/util/retry-function.ts
+++ b/src/util/retry-function.ts
@@ -1,0 +1,32 @@
+import { loadAsync } from 'node-yaml-config';
+import { sleep } from './sleep';
+
+export async function retryFunction(
+  functionToBeRetried: Promise<any>,
+  useConfig = false
+) {
+  let exitLoop = false;
+  let retries = 0;
+  let maxRetries = 3;
+  let retryInterval = 5000;
+  if (useConfig) {
+    const config = await loadAsync('cli.yml');
+    maxRetries = config.retries.retry_count;
+    retryInterval = config.retries.interval * 1000;
+  }
+
+  do {
+    try {
+      await functionToBeRetried;
+      exitLoop = true;
+    } catch (error) {
+      console.log(error);
+      retries++;
+      console.log(
+        `Retry ${retries - 1} out of max retries ${maxRetries} executed!`
+      );
+      await sleep(retryInterval);
+      if (retries === maxRetries) exitLoop = true;
+    }
+  } while (!exitLoop);
+}

--- a/src/util/sleep.ts
+++ b/src/util/sleep.ts
@@ -1,0 +1,5 @@
+export function sleep(ms: any) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
- simple configuration for include / exclude filters
- exclude beats include, if exclude filter is used, include is ignored
- added configurable retries on graphql requests

To use it, update the sample config, e.g.:

```yml
default:
  filters:
    users:
      include:
      exclude:
    organizations:
      include:
      exclude:
    hubs:
      include:
        - ef42661b-d7e0-40e8-a763-5b69b2b3a365
        - cf42661b-d7e0-40e8-a763-5b69b2b3a366
      exclude:
  retries:
    retry_count: 3
    interval: 5
```

And then either run  `npm run authorization-reset-with-config` - that will run all resets with the configuration, or e.g. `npm run authorization-reset-all-hubs true`, that will run the filter only on hubs and apply the authorization.