### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v7
       - name: Prepare
         id: prep
         run: |
@@ -39,18 +39,18 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "created={$(date -u +'%Y-%m-%dT%H:%M:%SZ')}" >> $GITHUB_OUTPUT
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Bump GitHub Actions to latest releases (org-wide actions audit, 2026-07-21).

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v3.0.2 | v7 |
| `docker/build-push-action` | v5.0.0 | v7 |
| `docker/login-action` | v3.0.0 | v4 |
| `docker/setup-buildx-action` | v3.0.0 | v4 |
| `docker/setup-qemu-action` | v3.0.0 | v4 |

Compatibility: all `with:` inputs validated against each action's schema at the target version; bumped actions run on node24 (GitHub-hosted runners OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image release process to use newer build, authentication, and deployment tooling.
  * Existing release triggers, version tags, and publishing behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->